### PR TITLE
Fixed default angle value for CLI

### DIFF
--- a/include/prawnsushi.gmic
+++ b/include/prawnsushi.gmic
@@ -79,7 +79,6 @@ arg0 $12,\
        "shapemax0","shapeprevalent","softburn","softdodge","softlight","stamp","subtract","value","vividlight","xor"
   blending_mode=${}
   n 0,255
-
   foreach {
 
     wi,he:=w,h


### PR DESCRIPTION
Fixed default angle value for CLI : It was an error in the "skip" command values (1 instead of 0, probably because i used "int" sliders before you changed to "choice")